### PR TITLE
Add card draw web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # echoes-of-dawn
-Website For Echoes Of Dawn
+
+Simple card drawing preview site.
+
+## Running locally
+
+1. Install a static server such as `serve` or use Python:
+   ```bash
+   npx serve .
+   # or
+   python3 -m http.server
+   ```
+2. Open `http://localhost:5000/index.html` (or whichever port the server prints).
+
+The signup form posts to `api/signup` which writes submitted emails to `emails.txt`.
+
+## Coming soon
+
+The draw page includes a placeholder that will soon provide AI-generated readings for each card. For now, a simple message is shown after each draw.

--- a/api/signup.js
+++ b/api/signup.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+module.exports = (req, res) => {
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    return res.end('Method Not Allowed');
+  }
+
+  let body = '';
+  req.on('data', chunk => (body += chunk));
+  req.on('end', () => {
+    const params = new URLSearchParams(body);
+    const email = params.get('email');
+    if (email) {
+      const file = path.join(__dirname, '..', 'emails.txt');
+      fs.appendFileSync(file, email + '\n');
+    }
+    res.statusCode = 200;
+    res.end('OK');
+  });
+};

--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Echoes of Dawn - Card Draw</title>
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+</head>
+<body>
+  <h1>Echoes of Dawn</h1>
+  <div id="preview-container">
+    <img id="card-preview" src="public/cards/card1.svg" alt="Card Preview" />
+  </div>
+  <button id="draw-btn">Draw Card</button>
+  <form id="signup-form" action="api/signup" method="POST">
+    <label>
+      Email:
+      <input type="email" name="email" required />
+    </label>
+    <label>
+      <input type="checkbox" name="custom" />
+      Custom inspiration
+    </label>
+    <button type="submit">Sign Up</button>
+  </form>
+  <p id="reading">AI reading coming soon...</p>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/cards/card1.svg
+++ b/public/cards/card1.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='300'>
+  <rect width='200' height='300' fill='#FBE8A6'/>
+  <text x='100' y='150' font-size='24' text-anchor='middle' fill='#333'>Card 1</text>
+</svg>

--- a/public/cards/card2.svg
+++ b/public/cards/card2.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='300'>
+  <rect width='200' height='300' fill='#A6D9F7'/>
+  <text x='100' y='150' font-size='24' text-anchor='middle' fill='#333'>Card 2</text>
+</svg>

--- a/public/cards/card3.svg
+++ b/public/cards/card3.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='200' height='300'>
+  <rect width='200' height='300' fill='#D9A6F7'/>
+  <text x='100' y='150' font-size='24' text-anchor='middle' fill='#333'>Card 3</text>
+</svg>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,20 @@
+const cards = [
+  'public/cards/card1.svg',
+  'public/cards/card2.svg',
+  'public/cards/card3.svg'
+];
+
+const preview = document.getElementById('card-preview');
+const reading = document.getElementById('reading');
+
+document.getElementById('draw-btn').addEventListener('click', () => {
+  const card = cards[Math.floor(Math.random() * cards.length)];
+  preview.src = card;
+  reading.textContent = 'Generating reading...';
+
+  html2canvas(document.getElementById('preview-container')).then(canvas => {
+    // Placeholder for screenshot use
+    console.log('Screenshot captured');
+    reading.textContent = 'AI reading coming soon...';
+  });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,27 @@
+body {
+  font-family: Arial, sans-serif;
+  text-align: center;
+  padding: 2rem;
+}
+
+#preview-container {
+  margin: 1rem auto;
+  width: 200px;
+  height: 300px;
+}
+
+#card-preview {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border: 1px solid #ccc;
+}
+
+#signup-form {
+  margin-top: 1rem;
+}
+
+label {
+  display: block;
+  margin: 0.5rem 0;
+}


### PR DESCRIPTION
## Summary
- add minimal web content with card draw preview
- include styles, client-side JS and a simple signup API
- provide placeholder card images
- update README with local running instructions and mention AI features

## Testing
- `node -e "require('./api/signup.js')({method:'POST',on:function(){},end:function(){},})"` *(fails: cannot run due to missing request simulation)*
